### PR TITLE
Install Windows openssl executable

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,6 +29,7 @@ nmake -f ms\ntdll.mak test
 if errorlevel 1 exit 1
 
 REM Install step
+copy out32dll\openssl.exe %PREFIX%\openssl.exe
 copy out32\ssleay32.lib %LIBRARY_LIB%\ssleay32_static.lib
 copy out32\libeay32.lib %LIBRARY_LIB%\libeay32_static.lib
 copy out32dll\ssleay32.lib %LIBRARY_LIB%\ssleay32.lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,10 @@ test:
     - python   3.5.*   # [py35]
   imports:
     - ssl
+  commands:
+    - copy NUL checksum.txt        # [win]
+    - touch checksum.txt           # [unix]
+    - openssl sha256 checksum.txt
 
 about:
   home: http://www.openssl.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
 
 build:
-  number: 1
+  number: 2
   no_link: lib/libcrypto.so.1.0.0        # [linux]
   no_link: lib/libcrypto.1.0.0.dylib     # [osx]
   detect_binary_files_with_prefix: True  # [unix]


### PR DESCRIPTION
This tries to install `openssl.exe` on Windows. We already do this on Unix builds. It appears this executable is being built on Windows, but we are not installing. This attempts to install it. Should add this binary is very useful for computing various checksums on the command line. Feedback welcome.

cc @msarahan @patricksnape @gillins @ocefpaf