### PR TITLE
Fix install command

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -76,7 +76,7 @@ if [[ "${HOST}" == "${BUILD}" ]]; then
     exit 1
   fi
 fi
-make install_sw
+make install_sw install_ssldirs
 
 # https://github.com/ContinuumIO/anaconda-issues/issues/6424
 if [[ ${HOST} =~ .*linux.* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b
 
 build:
-  number: 0
+  number: 1
   no_link: lib/libcrypto.so.1.1        # [linux]
   no_link: lib/libcrypto.1.1.dylib     # [osx]
   has_prefix_files:                      # [unix]


### PR DESCRIPTION
The current build script doesn't fully install openssl as [since openssl 1.1.0](https://github.com/openssl/openssl/commit/4813ad2d245cbf7fed2898d173eaa9e2a00e3e23#diff-ab8fca5fe83f249a731bd7f4cf045b36L271) the `make install` command has included `install_ssldirs` as well as `install_sw`.

@conda-forge-admin, please rerender