### PR TITLE
Static OpenSSL on windows

### DIFF
--- a/recipe/install_libopenssl-static.bat
+++ b/recipe/install_libopenssl-static.bat
@@ -1,0 +1,3 @@
+if not exist "%LIBRARY_LIB%" mkdir %LIBRARY_LIB%
+copy libcrypto_static.lib %LIBRARY_LIB%\libcrypto_static.lib
+copy libssl_static.lib %LIBRARY_LIB%\libssl_static.lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,16 +54,18 @@ outputs:
         - touch checksum.txt           # [unix]
         - openssl sha256 checksum.txt
 
-  - name: libopenssl-static                   # [unix]
-    requirements:                             # [unix]
-      build:                                  # [unix]
-        - {{ compiler('c') }}                 # [unix]
+  - name: libopenssl-static
+    requirements:
+      build:
+        - {{ compiler('c') }}
     script: install_libopenssl-static.sh      # [unix]
-    test:                                     # [unix]
-      commands:                               # [unix]
-        - test -f ${PREFIX}/lib/libcrypto.a   # [unix]
-        - test -f ${PREFIX}/lib/libssl.a      # [unix]
-
+    script: install_libopenssl-static.bat     # [win]
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libcrypto.a                   # [unix]
+        - test -f ${PREFIX}/lib/libssl.a                      # [unix]
+        - if exist %LIBRARY_PREFIX%\lib\libcrypto_static.lib (exit 0) else (exit 1)  # [win]
+        - if exist %LIBRARY_PREFIX%\lib\libssl_static.lib (exit 0) else (exit 1)     # [win]
 
 about:
   home: http://www.openssl.org/


### PR DESCRIPTION
This appears to be working. The new `install_libopenssl-static.bat` is very much in the spirit as `install_libopenssl-static.sh`.

I am still unsure of 

 - why aren't `libcrypto_static.lib` and `libssl_static.lib` not installed by default with `nmake install`, unlike their Unix counterparts? I opened the followinf issue upstream: https://github.com/openssl/openssl/issues/12358 
 - also, I am trying to use them in a downstream package right now and `OPENSSL_USE_STATIC_LIBS` does not seem to have any effect on windows. The issue was acknowledged as a bug in cmake's FindOpenSSL: https://gitlab.kitware.com/cmake/cmake/-/issues/20903.

