### PR TITLE
updated v1.1.1l

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1k" %}
+{% set version = "1.1.1l" %}
 
 package:
   name: openssl_split
@@ -6,7 +6,7 @@ package:
 
 source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz
-  sha256: 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
+  sha256: 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
   patches:
     - 0001-Don-t-use-USE_BCRYPTGENRANDOM-for-VS-older-than-2015.patch
 


### PR DESCRIPTION
OpenSSL 1.1.1l was released on August 24 with a fix for a high-severity security hole, CVE-2021-3711 .