### PR TITLE
backport fix to include applink.c

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,12 @@ source:
     # backport from openssl/openssl#16593 to simplify & future-proof build;
     # can be dropped for any version after 3.0.0
     - patches/0001-80-test_cmp_http.t-Fix-handling-of-empty-HTTP-proxy-.patch
+    # backport from openssl/openssl#16577, can be dropped for any version after 3.0.0
+    # needed to have applink.c in include/openssl (e.g. necessary for python)
+    - patches/0002-Fix-the-build-file-templates-where-uplink-matters.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/patches/0001-80-test_cmp_http.t-Fix-handling-of-empty-HTTP-proxy-.patch
+++ b/recipe/patches/0001-80-test_cmp_http.t-Fix-handling-of-empty-HTTP-proxy-.patch
@@ -1,7 +1,8 @@
-From 4b931c1cae86411b42c3573ebb40b76999eb9ade Mon Sep 17 00:00:00 2001
+From 5f98ae04bcc79491e031b4655ef1877f0b012e3f Mon Sep 17 00:00:00 2001
 From: "Dr. David von Oheimb" <David.von.Oheimb@siemens.com>
 Date: Mon, 13 Sep 2021 08:14:58 +0200
-Subject: [PATCH] 80-test_cmp_http.t: Fix handling of empty HTTP proxy string
+Subject: [PATCH 1/2] 80-test_cmp_http.t: Fix handling of empty HTTP proxy
+ string
 
 Fixes #16546
 

--- a/recipe/patches/0002-Fix-the-build-file-templates-where-uplink-matters.patch
+++ b/recipe/patches/0002-Fix-the-build-file-templates-where-uplink-matters.patch
@@ -1,0 +1,68 @@
+From 1cf87abefd62bcf035bc3d33205528cf36fa9f27 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Fri, 10 Sep 2021 06:42:24 +0200
+Subject: [PATCH 2/2] Fix the build file templates where uplink matters
+
+We changed the manner in which a build needing applink is detected,
+but forgot to change the installation targets accordingly.
+
+Fixes #16570
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/16577)
+---
+ Configurations/unix-Makefile.tmpl    | 8 ++++----
+ Configurations/windows-makefile.tmpl | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index f88a70f482..b95a57779c 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -691,11 +691,11 @@ install_dev: install_runtime_libs
+ 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
+ 	@$(ECHO) "*** Installing development files"
+ 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/include/openssl
+-	@ : {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
++	@ : {- output_off() if $disabled{uplink}; "" -}
+ 	@$(ECHO) "install $(SRCDIR)/ms/applink.c -> $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c"
+ 	@cp $(SRCDIR)/ms/applink.c $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+ 	@chmod 644 $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+-	@ : {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
++	@ : {- output_on() if $disabled{uplink}; "" -}
+ 	@set -e; for i in $(SRCDIR)/include/openssl/*.h \
+ 			  $(BLDDIR)/include/openssl/*.h; do \
+ 		fn=`basename $$i`; \
+@@ -765,10 +765,10 @@ install_dev: install_runtime_libs
+ 
+ uninstall_dev: uninstall_runtime_libs
+ 	@$(ECHO) "*** Uninstalling development files"
+-	@ : {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
++	@ : {- output_off() if $disabled{uplink}; "" -}
+ 	@$(ECHO) "$(RM) $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c"
+ 	@$(RM) $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+-	@ : {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
++	@ : {- output_on() if $disabled{uplink}; "" -}
+ 	@set -e; for i in $(SRCDIR)/include/openssl/*.h \
+ 			  $(BLDDIR)/include/openssl/*.h; do \
+ 		fn=`basename $$i`; \
+diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
+index 26357c75bc..2687da319b 100644
+--- a/Configurations/windows-makefile.tmpl
++++ b/Configurations/windows-makefile.tmpl
+@@ -541,10 +541,10 @@ install_dev: install_runtime_libs
+ 	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
+ 	@$(ECHO) "*** Installing development files"
+ 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\include\openssl"
+-	@{- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
++	@{- output_off() if $disabled{uplink}; "" -}
+ 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\ms\applink.c" \
+ 				       "$(INSTALLTOP)\include\openssl"
+-	@{- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
++	@{- output_on() if $disabled{uplink}; "" -}
+ 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "-exclude_re=/__DECC_" \
+ 				       "$(SRCDIR)\include\openssl\*.h" \
+ 				       "$(INSTALLTOP)\include\openssl"
+-- 
+2.32.0.windows.2
+


### PR DESCRIPTION
Fix necessary to build (e.g.) python with openssl 3.0 on windows, see [here](https://github.com/conda-forge/python-feedstock/pull/501#issuecomment-929856540)

CC @chrisburr