### PR TITLE
explicitly build shared libraries on windows as well

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,6 +8,7 @@ REM Configure step
 perl configure %OSSL_CONFIGURE% ^
     --prefix=%LIBRARY_PREFIX% ^
     --openssldir=%LIBRARY_PREFIX% ^
+    shared ^
     enable-fips
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0002-Fix-the-build-file-templates-where-uplink-matters.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Currently cryptography is failing on win+openssl3, see [here](https://github.com/conda-forge/cryptography-feedstock/pull/80).

Someone on the cryptography upstream repo [suggested](https://github.com/pyca/cryptography/issues/6392#issuecomment-945365428) to build with `shared` (which, indeed is already the case on unix). Hope this will fix it.