### PR TITLE
backport fix for (exploitable?) avx512 heap corruption

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,12 @@ package:
 source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz
   sha256: 2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f
+  patches:
+    # backport fix for https://github.com/openssl/openssl/issues/18625
+    - patches/GH18626.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/patches/GH18626.patch
+++ b/recipe/patches/GH18626.patch
@@ -1,0 +1,34 @@
+From 4d8a88c134df634ba610ff8db1eb8478ac5fd345 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 22 Jun 2022 18:07:05 +0800
+Subject: [PATCH] rsa: fix bn_reduce_once_in_place call for
+ rsaz_mod_exp_avx512_x2
+
+bn_reduce_once_in_place expects the number of BN_ULONG, but factor_size
+is moduli bit size.
+
+Fixes #18625.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/18626)
+---
+ crypto/bn/rsaz_exp_x2.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/crypto/bn/rsaz_exp_x2.c b/crypto/bn/rsaz_exp_x2.c
+index 6b04486e3f56..f979cebd6fb7 100644
+--- a/crypto/bn/rsaz_exp_x2.c
++++ b/crypto/bn/rsaz_exp_x2.c
+@@ -257,6 +257,9 @@ int ossl_rsaz_mod_exp_avx512_x2(BN_ULONG *res1,
+     from_words52(res1, factor_size, rr1_red);
+     from_words52(res2, factor_size, rr2_red);
+ 
++    /* bn_reduce_once_in_place expects number of BN_ULONG, not bit size */
++    factor_size /= sizeof(BN_ULONG) * 8;
++
+     bn_reduce_once_in_place(res1, /*carry=*/0, m1, storage, factor_size);
+     bn_reduce_once_in_place(res2, /*carry=*/0, m2, storage, factor_size);
+ 


### PR DESCRIPTION
OpenSSL 3.0.4 has a pretty severe issue: https://github.com/openssl/openssl/issues/18625
See also https://guidovranken.com/2022/06/27/notes-on-openssl-remote-memory-corruption/

It's unclear when 3.0.5 will be released, so backport the fix.