### PR TITLE
Add pkgconfig metadata on windows

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang_bootstrap
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang_bootstrap
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,5 @@
+@echo on
+
 if "%ARCH%"=="32" (
     set OSSL_CONFIGURE=VC-WIN32
 ) ELSE (

--- a/recipe/install_openssl.bat
+++ b/recipe/install_openssl.bat
@@ -12,9 +12,10 @@ rd /s /q %LIBRARY_PREFIX%\html
 :: https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake
 mkdir %LIBRARY_PREFIX%\lib\pkgconfig
 for %%F in (openssl libssl libcrypto) DO (
-    copy %RECIPE_DIR%\win_pkgconfig\%%F.pc.in %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
-    sed -i "s|@PREFIX@|%LIBRARY_PREFIX:\=/%|g" %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
-    sed -i "s|@VERSION@|%PKG_VERSION%|g" %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
+    echo prefix=%LIBRARY_PREFIX:\=/% > %%F.pc
+    type %RECIPE_DIR%\win_pkgconfig\%%F.pc.in >> %%F.pc
+    echo Version: %PKG_VERSION% >> %%F.pc
+    copy %%F.pc %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
 )
 
 REM Install step

--- a/recipe/install_openssl.bat
+++ b/recipe/install_openssl.bat
@@ -1,8 +1,21 @@
+@echo on
+setlocal enabledelayedexpansion
+
 nmake install
 if %ERRORLEVEL% neq 0 exit 1
 
 :: don't include html docs that get installed
 rd /s /q %LIBRARY_PREFIX%\html
+
+:: install pkgconfig metadata (useful for downstream packages);
+:: adapted from inspecting the conda-forge .pc files for unix, as well as
+:: https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake
+mkdir %LIBRARY_PREFIX%\lib\pkgconfig
+for %%F in (openssl libssl libcrypto) DO (
+    copy %RECIPE_DIR%\win_pkgconfig\%%F.pc.in %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
+    sed -i "s|@PREFIX@|%LIBRARY_PREFIX:\=/%|g" %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
+    sed -i "s|@VERSION@|%PKG_VERSION%|g" %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
+)
 
 REM Install step
 rem copy out32dll\openssl.exe %PREFIX%\openssl.exe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ outputs:
       host:
       run:
         - ca-certificates
+        - ucrt             # [win]
     test:
       requires:
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        - m2-sed  # [win]
         - make
         - perl *
       # Empty host section to ensure that this is identified as cb3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - m2-sed  # [win]
         - make
         - perl *
       # Empty host section to ensure that this is identified as cb3
@@ -43,11 +44,16 @@ outputs:
       run:
         - ca-certificates
     test:
+      requires:
+        - pkg-config
       commands:
         - copy NUL checksum.txt        # [win]
         - touch checksum.txt           # [unix]
         - $PREFIX/bin/openssl sha256 checksum.txt       # [unix]
         - '%LIBRARY_BIN%\openssl sha256 checksum.txt'   # [win]
+
+        # test pkgconfig metadata
+        - pkg-config --print-errors --exact-version "{{ version }}" openssl
 
   - name: libopenssl-static
     script: install_libopenssl-static.sh   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
 
 outputs:
   - name: openssl
+    script: install_openssl.sh   # [unix]
+    script: install_openssl.bat  # [win]
     build:
       no_link: lib/libcrypto.so.3.0  # [linux]
       no_link: lib/libcrypto.3.0.dylib  # [osx]
@@ -40,8 +42,6 @@ outputs:
       host:
       run:
         - ca-certificates
-    script: install_openssl.sh  # [unix]
-    script: install_openssl.bat  # [win]
     test:
       commands:
         - copy NUL checksum.txt        # [win]
@@ -50,11 +50,11 @@ outputs:
         - '%LIBRARY_BIN%\openssl sha256 checksum.txt'   # [win]
 
   - name: libopenssl-static
+    script: install_libopenssl-static.sh   # [unix]
+    script: install_libopenssl-static.bat  # [win]
     requirements:
       build:
         - {{ compiler('c') }}
-    script: install_libopenssl-static.sh  # [unix]
-    script: install_libopenssl-static.bat  # [win]
     test:
       commands:
         - test -f ${PREFIX}/lib/libcrypto.a                   # [unix]

--- a/recipe/win_pkgconfig/libcrypto.pc.in
+++ b/recipe/win_pkgconfig/libcrypto.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: OpenSSL-libcrypto
+Description: OpenSSL cryptography library
+Version: @VERSION@
+Libs: -L"${libdir}" -llibcrypto
+Libs.private: -lcrypt32 -lws2_32
+Cflags: -I"${includedir}"

--- a/recipe/win_pkgconfig/libcrypto.pc.in
+++ b/recipe/win_pkgconfig/libcrypto.pc.in
@@ -1,11 +1,9 @@
-prefix=@PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: @VERSION@
 Libs: -L"${libdir}" -llibcrypto
 Libs.private: -lcrypt32 -lws2_32
 Cflags: -I"${includedir}"

--- a/recipe/win_pkgconfig/libssl.pc.in
+++ b/recipe/win_pkgconfig/libssl.pc.in
@@ -1,0 +1,9 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: OpenSSL
+Description: Secure Sockets Layer and cryptography libraries and tools
+Version: @VERSION@
+Requires: libssl libcrypto

--- a/recipe/win_pkgconfig/libssl.pc.in
+++ b/recipe/win_pkgconfig/libssl.pc.in
@@ -1,9 +1,7 @@
-prefix=@PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: OpenSSL
 Description: Secure Sockets Layer and cryptography libraries and tools
-Version: @VERSION@
 Requires: libssl libcrypto

--- a/recipe/win_pkgconfig/openssl.pc.in
+++ b/recipe/win_pkgconfig/openssl.pc.in
@@ -1,0 +1,9 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: OpenSSL
+Description: Secure Sockets Layer and cryptography libraries and tools
+Version: @VERSION@
+Requires: libssl libcrypto

--- a/recipe/win_pkgconfig/openssl.pc.in
+++ b/recipe/win_pkgconfig/openssl.pc.in
@@ -1,9 +1,7 @@
-prefix=@PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: OpenSSL
 Description: Secure Sockets Layer and cryptography libraries and tools
-Version: @VERSION@
 Requires: libssl libcrypto


### PR DESCRIPTION
This would be useful to be able to run test for pkgconfig-metadata in dependent repos, e.g. grpc-cpp, c.f. https://github.com/conda-forge/grpc-cpp-feedstock/pull/239

Content is taken from https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake and cross-referenced with our own pkgconfig files on unix (from where I took the formatting).