### PR TITLE
test openssl 3.1.0-beta1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: openssl_split
-  version: {{ version }}
+  version: {{ version.replace("-", ".") }}
 
 source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.7" %}
+{% set version = "3.1.0-beta1" %}
 
 package:
   name: openssl_split
@@ -6,10 +6,10 @@ package:
 
 source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz
-  sha256: 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
+  sha256: e0d4bb52f7f9a745127b533be1c42bd4743467b180e7bc28a3d6ed40410c86d0
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Upstream [considers](https://www.openssl.org/blog/blog/2022/12/21/OpenSSL3.1Beta/) this a release candidate already.