### PR TITLE
Apply patch from upstream

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang_bootstrap
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang_bootstrap
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/0001-OBJ_nid2obj-Return-UNDEF-object-instead-of-NULL.patch
+++ b/recipe/0001-OBJ_nid2obj-Return-UNDEF-object-instead-of-NULL.patch
@@ -1,0 +1,66 @@
+From b9b8e9ee9dd2a3eb2876ec45605c64f343d5548e Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Tue, 21 Mar 2023 11:36:56 +0100
+Subject: [PATCH] OBJ_nid2obj(): Return UNDEF object instead of NULL for
+ NID_undef
+
+Fixes a regression from 3.0 from the obj creation refactoring.
+
+Fixes #20555
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20556)
+
+(cherry picked from commit 908ba3ed9adbb3df90f7684a3111ca916a45202d)
+---
+ crypto/objects/obj_dat.c  |  7 +++----
+ test/asn1_internal_test.c | 11 +++++++++++
+ 2 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/objects/obj_dat.c b/crypto/objects/obj_dat.c
+index f45e34a63940..ee1ada85d16d 100644
+--- a/crypto/objects/obj_dat.c
++++ b/crypto/objects/obj_dat.c
+@@ -311,10 +311,9 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
+     ADDED_OBJ ad, *adp = NULL;
+     ASN1_OBJECT ob;
+ 
+-    if (n == NID_undef)
+-        return NULL;
+-    if (n >= 0 && n < NUM_NID && nid_objs[n].nid != NID_undef)
+-            return (ASN1_OBJECT *)&(nid_objs[n]);
++    if (n == NID_undef
++        || (n > 0 && n < NUM_NID && nid_objs[n].nid != NID_undef))
++        return (ASN1_OBJECT *)&(nid_objs[n]);
+ 
+     ad.type = ADDED_NID;
+     ad.obj = &ob;
+diff --git a/test/asn1_internal_test.c b/test/asn1_internal_test.c
+index 61e4265c8b71..9fb2938e4554 100644
+--- a/test/asn1_internal_test.c
++++ b/test/asn1_internal_test.c
+@@ -190,11 +190,22 @@ static int test_unicode_range(void)
+     return ok;
+ }
+ 
++static int test_obj_nid_undef(void)
++{
++    if (!TEST_ptr(OBJ_nid2obj(NID_undef))
++        || !TEST_ptr(OBJ_nid2sn(NID_undef))
++        || !TEST_ptr(OBJ_nid2ln(NID_undef)))
++        return 0;
++
++    return 1;
++}
++
+ int setup_tests(void)
+ {
+     ADD_TEST(test_tbl_standard);
+     ADD_TEST(test_standard_methods);
+     ADD_TEST(test_empty_nonoptional_content);
+     ADD_TEST(test_unicode_range);
++    ADD_TEST(test_obj_nid_undef);
+     return 1;
+ }

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz
   sha256: aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
   patches:
+    # backport openssl/openssl#20556 as regression fix; can be dropped for v>3.1.0
     - 0001-OBJ_nid2obj-Return-UNDEF-object-instead-of-NULL.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz
   sha256: aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
+  patches:
+    - 0001-OBJ_nid2obj-Return-UNDEF-object-instead-of-NULL.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-OBJ_nid2obj-Return-UNDEF-object-instead-of-NULL.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This picks up the patch for https://github.com/openssl/openssl/issues/20555 which was already merged upstream for OpenSSL `3.1.1`: https://github.com/openssl/openssl/commit/908ba3ed9adbb3df90f7684a3111ca916a45202d

See https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4360 for some more context.