### PR TITLE
Backport another OpenSSL patch

### DIFF
--- a/recipe/0002-Fix-some-patches-related-to-error-exiting.patch
+++ b/recipe/0002-Fix-some-patches-related-to-error-exiting.patch
@@ -1,0 +1,39 @@
+From 1c0732e48340f683e638c309e4c5f231af58d23e Mon Sep 17 00:00:00 2001
+From: Peiwei Hu <jlu.hpw@foxmail.com>
+Date: Wed, 5 Jan 2022 23:17:53 +0800
+Subject: [PATCH] Fix: some patches related to error exiting
+
+Fixes #20613
+
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20615)
+---
+ crypto/objects/obj_dat.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/objects/obj_dat.c b/crypto/objects/obj_dat.c
+index ee1ada85d16d..e8377e9fc309 100644
+--- a/crypto/objects/obj_dat.c
++++ b/crypto/objects/obj_dat.c
+@@ -742,16 +742,17 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
+     if ((sn != NULL && OBJ_sn2nid(sn) != NID_undef)
+             || (ln != NULL && OBJ_ln2nid(ln) != NID_undef)) {
+         ERR_raise(ERR_LIB_OBJ, OBJ_R_OID_EXISTS);
+-        goto err;
++        return 0;
+     }
+ 
+     /* Convert numerical OID string to an ASN1_OBJECT structure */
+     tmpoid = OBJ_txt2obj(oid, 1);
+     if (tmpoid == NULL)
+-        goto err;
++        return 0;
+ 
+     if (!ossl_obj_write_lock(1)) {
+         ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
++        ASN1_OBJECT_free(tmpoid);
+         return 0;
+     }
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   patches:
     # backport openssl/openssl#20556 as regression fix; can be dropped for v>3.1.0
     - 0001-OBJ_nid2obj-Return-UNDEF-object-instead-of-NULL.patch
+    # backport openssl/openssl#20613 as regression fix; can be dropped for v>3.1.0
+    - 0002-Fix-some-patches-related-to-error-exiting.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Similar to #123, another patch which has already been upstreamed: https://github.com/openssl/openssl/commit/1c0732e48340f683e638c309e4c5f231af58d23e

I've seen it manifest as a deadlock which only happens on CentOS 7-like systems (RHEL 8, Alama 9 and Arch Linux are all unaffected).