### PR TITLE
Backport winsock2 patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,12 @@ package:
 source:
   url: http://www.openssl.org/source/openssl-{{ version }}.tar.gz
   sha256: 14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e
+  patches:
+    # https://github.com/openssl/openssl/issues/22811
+    - winsock2.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/winsock2.patch
+++ b/recipe/winsock2.patch
@@ -1,0 +1,38 @@
+From b0e9d0370262ade64c55f2385fbb09ec6aa81e76 Mon Sep 17 00:00:00 2001
+From: Hugo Landau <hlandau@openssl.org>
+Date: Fri, 24 Nov 2023 10:03:30 +0000
+Subject: [PATCH] Only include winsock2.h for struct timeval if needed
+
+Fixes #22811
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
+(Merged from https://github.com/openssl/openssl/pull/22813)
+
+(cherry picked from commit ba58e9f1e22dd9ee2e37078640dcbe9f520a555d)
+---
+ include/openssl/e_ostime.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/include/openssl/e_ostime.h b/include/openssl/e_ostime.h
+index 8a7cc9880fa79..0e17487504992 100644
+--- a/include/openssl/e_ostime.h
++++ b/include/openssl/e_ostime.h
+@@ -22,7 +22,15 @@
+  */
+ 
+ # if defined(OPENSSL_SYS_WINDOWS)
+-#  include <winsock2.h>
++#  if !defined(_WINSOCKAPI_)
++    /*
++     * winsock2.h defines _WINSOCK2API_ and both winsock2.h and winsock.h define
++     * _WINSOCKAPI_. Both of these provide struct timeval. Don't include
++     * winsock2.h if either header has been included to avoid breakage with
++     * applications that prefer to use <winsock.h> over <winsock2.h>.
++     */
++#   include <winsock2.h>
++#  endif
+ # else
+ #  include <sys/time.h>
+ # endif


### PR DESCRIPTION
see https://github.com/openssl/openssl/issues/22811
needed for qt6 feedstock
@conda-forge-admin please rerender