### PR TITLE
Fix CRLF in activation scripts that need to be bash-compatible

### DIFF
--- a/recipe/.gitattributes
+++ b/recipe/.gitattributes
@@ -1,0 +1,3 @@
+# explicitly set LF line endings for these files even on windows
+# because we need to support (de)activation from bash
+*-win.sh text eol=lf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ outputs:
     test:
       requires:
         - pkg-config
+        - ripgrep
       commands:
         - copy NUL checksum.txt        # [win]
         - touch checksum.txt           # [unix]
@@ -63,6 +64,13 @@ outputs:
 
         # test pkgconfig metadata
         - pkg-config --print-errors --exact-version "{{ version }}" openssl
+
+        # ensure (de)activation scripts for bash-on-win do not contain crlf line endings;
+        # ripgrep will return exit code 1 if no match is found, which is what we want after
+        # filtering to the carriage-return character that shouldn't be there.
+        {% for task in ["activate", "deactivate"] %}
+        - type %CONDA_PREFIX%\etc\conda\{{ task }}.d\openssl_{{ task }}-win.sh | rg \r & if %ERRORLEVEL% NEQ 1 (exit 0) else (exit 1)  # [win]
+        {% endfor %}
 
   - name: libopenssl-static
     script: install_libopenssl-static.sh  # [unix]


### PR DESCRIPTION
Cleaned up version of #166, with a test