### PR TITLE
fix: Using "safe" environment setting

### DIFF
--- a/recipe/activate-win.bat
+++ b/recipe/activate-win.bat
@@ -1,9 +1,9 @@
 @echo off
 if "%SSL_CERT_FILE%"=="" (
-    set SSL_CERT_FILE=%CONDA_PREFIX%\Library\ssl\cacert.pem
+    set "SSL_CERT_FILE=%CONDA_PREFIX%\Library\ssl\cacert.pem"
     set "__CONDA_OPENSSL_CERT_FILE_SET=1"
 )
 if "%SSL_CERT_DIR%"=="" (
-    set SSL_CERT_DIR=%CONDA_PREFIX%\Library\ssl\certs
+    set "SSL_CERT_DIR=%CONDA_PREFIX%\Library\ssl\certs"
     set "__CONDA_OPENSSL_CERT_DIR_SET=1"
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

This was found by a user in `pixi`: https://github.com/prefix-dev/pixi/issues/3714

Not sure what we can do on the `pixi` side to improve this, but I found that this fixes the issue for me locally. 

To test this you can do the following on Windows:
```
mkdir "TEST (some dir)"

cd "TEST (some dir)"

pixi init

pixi add python
# Fails
pixi run echo hello
# Fails
```
Now change the `.pixi/envs/default/etc/conda/activate.d/openssl_activate-win.bat` to the file I change in this PR.

```
pixi add python
# Succeeds now :tada:
```
